### PR TITLE
fix test error when not running with AUTHOR_TEST

### DIFF
--- a/t/05-cmd.t
+++ b/t/05-cmd.t
@@ -2,6 +2,7 @@
 use 5.20.0;
 use strict;
 use warnings FATAL => 'all';
+no warnings 'once';
 BEGIN { $ENV{MAIL_BIMI_CACHE_BACKEND} = 'Null' };
 use lib 't';
 use Test::RequiresInternet;


### PR DESCRIPTION
Addresses [t/05-cmd.t fails (with new MooseX::Getopt?)](https://github.com/marcbradshaw/mail-bimi/issues/5)