### PR TITLE
Add support 'Size' messages of Mail::BIMI::Indicator::app_validate().

### DIFF
--- a/t/data/app-checkdomain-fastmaildmarc.stdout
+++ b/t/data/app-checkdomain-fastmaildmarc.stdout
@@ -37,6 +37,9 @@ Indicator (From Location) Returned: [32m✓[0m
     IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K[0m
 [33m  Profile Used   [37m: [36mSVG_1.2_PS[0m
 [33m  Is Valid       [37m: [32mYes[0m
+[33m  Size (raw)     [37m: 1026 bytes[0m
+[33m  Size (unzip)   [37m: 1026 bytes[0m
+[33m  Size (header)  [37m: 1498 bytes[0m
 
 An authenticated email with this record would receive the following BIMI results:
 

--- a/t/data/app-checkdomain-profile-bimi.stdout
+++ b/t/data/app-checkdomain-profile-bimi.stdout
@@ -37,6 +37,9 @@ Indicator (From Location) Returned: [32m✓[0m
     IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K[0m
 [33m  Profile Used   [37m: [36mSVG_1.2_BIMI[0m
 [33m  Is Valid       [37m: [32mYes[0m
+[33m  Size (raw)     [37m: 1026 bytes[0m
+[33m  Size (unzip)   [37m: 1026 bytes[0m
+[33m  Size (header)  [37m: 1498 bytes[0m
 
 An authenticated email with this record would receive the following BIMI results:
 

--- a/t/data/app-checkdomain-profile-tiny.stdout
+++ b/t/data/app-checkdomain-profile-tiny.stdout
@@ -37,6 +37,9 @@ Indicator (From Location) Returned: [32m✓[0m
     IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K[0m
 [33m  Profile Used   [37m: [36mTiny-1.2[0m
 [33m  Is Valid       [37m: [32mYes[0m
+[33m  Size (raw)     [37m: 1026 bytes[0m
+[33m  Size (unzip)   [37m: 1026 bytes[0m
+[33m  Size (header)  [37m: 1498 bytes[0m
 
 An authenticated email with this record would receive the following BIMI results:
 

--- a/t/data/app-checksvg-file-tiny.stdout
+++ b/t/data/app-checksvg-file-tiny.stdout
@@ -27,4 +27,7 @@ Indicator Returned: [32m✓[0m
     IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K[0m
 [33m  Profile Used   [37m: [36mTiny-1.2[0m
 [33m  Is Valid       [37m: [32mYes[0m
+[33m  Size (raw)     [37m: 1026 bytes[0m
+[33m  Size (unzip)   [37m: 1026 bytes[0m
+[33m  Size (header)  [37m: 1498 bytes[0m
 

--- a/t/data/app-checksvg-file.stdout
+++ b/t/data/app-checksvg-file.stdout
@@ -27,4 +27,7 @@ Indicator Returned: [32m✓[0m
     IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K[0m
 [33m  Profile Used   [37m: [36mSVG_1.2_PS[0m
 [33m  Is Valid       [37m: [32mYes[0m
+[33m  Size (raw)     [37m: 1026 bytes[0m
+[33m  Size (unzip)   [37m: 1026 bytes[0m
+[33m  Size (header)  [37m: 1498 bytes[0m
 

--- a/t/data/app-checksvg-uri.stdout
+++ b/t/data/app-checksvg-uri.stdout
@@ -27,4 +27,7 @@ Indicator Returned: [32m✓[0m
     IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K[0m
 [33m  Profile Used   [37m: [36mSVG_1.2_PS[0m
 [33m  Is Valid       [37m: [32mYes[0m
+[33m  Size (raw)     [37m: 1026 bytes[0m
+[33m  Size (unzip)   [37m: 1026 bytes[0m
+[33m  Size (header)  [37m: 1498 bytes[0m
 


### PR DESCRIPTION
In lib/Mail/BIMI/Indicator.pm, app_validate() method say "Size (raw|unzip|header)" messages, so test failed like following:

```
t/05-cmd.t ........................ Name "Mail::BIMI::TestSuite::Resolver" used only once: possible typo at t/05-cmd.t line 26.

        #   Failed test 'STDOUT as expected'
        #   at t/05-cmd.t line 200.
        # +---+-----------------------------------------------------------------------------------+---+-----------------------------------------------------------------------------------+
        # | Ln|Got                                                                                | Ln|Expected                                                                           |
        # +---+-----------------------------------------------------------------------------------+---+-----------------------------------------------------------------------------------+
        # | 37|    IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K\e[0m                                    | 37|    IgZmlsbD0iIzMzM2U0OCIvPjwvZz48L3N2Zz4K\e[0m                                    |
        # | 38|\e[33m  Profile Used   \e[37m: \e[36mSVG_1.2_PS\e[0m                               | 38|\e[33m  Profile Used   \e[37m: \e[36mSVG_1.2_PS\e[0m                               |
        # | 39|\e[33m  Is Valid       \e[37m: \e[32mYes\e[0m                                      | 39|\e[33m  Is Valid       \e[37m: \e[32mYes\e[0m                                      |
        # * 40|\e[33m  Size (raw)     \e[37m: 1026 bytes\e[0m                                     *   |                                                                                   |
        # * 41|\e[33m  Size (unzip)   \e[37m: 1026 bytes\e[0m                                     *   |                                                                                   |
        # * 42|\e[33m  Size (header)  \e[37m: 1498 bytes\e[0m                                     *   |                                                                                   |
        # | 43|                                                                                   | 40|                                                                                   |
        # | 44|An authenticated email with this record would receive the following BIMI results:  | 41|An authenticated email with this record would receive the following BIMI results:  |
        # | 45|                                                                                   | 42|                                                                                   |
        # +---+-----------------------------------------------------------------------------------+---+-----------------------------------------------------------------------------------+
        # Looks like you failed 1 test of 3.
```