### PR TITLE
Replace TAB to 4 SPACEs.

### DIFF
--- a/t/data/app-bare-help.stdout
+++ b/t/data/app-bare-help.stdout
@@ -1,5 +1,5 @@
 05-cmd.t <command> [-?h] [long options...]
-	-? -h --help  show help
+    -? -h --help  show help
 
 Available commands:
 

--- a/t/data/app-bare.stdout
+++ b/t/data/app-bare.stdout
@@ -1,5 +1,5 @@
 05-cmd.t <command> [-?h] [long options...]
-	-? -h --help  show help
+    -? -h --help  show help
 
 Available commands:
 

--- a/t/data/app-checkdomain-help.stdout
+++ b/t/data/app-checkdomain-help.stdout
@@ -1,7 +1,7 @@
 05-cmd.t checkdomain [long options...] <DOMAIN>
 
 Check the BIMI assertion record for a given domain
-	--profile STR   SVG Profile to validate against
-	                (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--selector STR  Optional selector
+    --profile STR   SVG Profile to validate against
+                    (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --selector STR  Optional selector
 

--- a/t/data/app-checkdomain-multi.error
+++ b/t/data/app-checkdomain-multi.error
@@ -1,9 +1,9 @@
 Error: Multiple Domains specified
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checkdomain [long options...] <DOMAIN>
-	--profile STR   SVG Profile to validate against
-	                (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--selector STR  Optional selector
+    --profile STR   SVG Profile to validate against
+                    (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --selector STR  Optional selector

--- a/t/data/app-checkdomain-nodomain.error
+++ b/t/data/app-checkdomain-nodomain.error
@@ -1,9 +1,9 @@
 Error: No Domain specified
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checkdomain [long options...] <DOMAIN>
-	--profile STR   SVG Profile to validate against
-	                (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--selector STR  Optional selector
+    --profile STR   SVG Profile to validate against
+                    (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --selector STR  Optional selector

--- a/t/data/app-checkdomain-profile-bad.error
+++ b/t/data/app-checkdomain-profile-bad.error
@@ -1,9 +1,9 @@
 Error: Unknown SVG Profile
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checkdomain [long options...] <DOMAIN>
-	--profile STR   SVG Profile to validate against
-	                (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--selector STR  Optional selector
+    --profile STR   SVG Profile to validate against
+                    (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --selector STR  Optional selector

--- a/t/data/app-checkrecord-help.stdout
+++ b/t/data/app-checkrecord-help.stdout
@@ -1,7 +1,7 @@
 05-cmd.t checkrecord [long options...] <RECORD>
 
 Check a given BIMI assertion record
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--domain STR   Optional domain
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --domain STR   Optional domain
 

--- a/t/data/app-checkrecord-norecord.error
+++ b/t/data/app-checkrecord-norecord.error
@@ -1,9 +1,9 @@
 Error: No Record specified
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checkrecord [long options...] <RECORD>
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--domain STR   Optional domain
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --domain STR   Optional domain

--- a/t/data/app-checkrecord-profile-bad.error
+++ b/t/data/app-checkrecord-profile-bad.error
@@ -1,9 +1,9 @@
 Error: Unknown SVG Profile
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checkrecord [long options...] <RECORD>
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--domain STR   Optional domain
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --domain STR   Optional domain

--- a/t/data/app-checkrecords-multi.error
+++ b/t/data/app-checkrecords-multi.error
@@ -1,9 +1,9 @@
 Error: Multiple Records specified
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checkrecord [long options...] <RECORD>
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--domain STR   Optional domain
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --domain STR   Optional domain

--- a/t/data/app-checksvg-file-badprofile.error
+++ b/t/data/app-checksvg-file-badprofile.error
@@ -1,9 +1,9 @@
 Error: Unknown SVG Profile
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checksvg [long options...] <URI>
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--fromfile     Fetch from file instead of from URI
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --fromfile     Fetch from file instead of from URI

--- a/t/data/app-checksvg-file-multi.error
+++ b/t/data/app-checksvg-file-multi.error
@@ -1,9 +1,9 @@
 Error: Multiple URIs specified
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checksvg [long options...] <URI>
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--fromfile     Fetch from file instead of from URI
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --fromfile     Fetch from file instead of from URI

--- a/t/data/app-checksvg-help.stdout
+++ b/t/data/app-checksvg-help.stdout
@@ -1,7 +1,7 @@
 05-cmd.t checksvg [long options...] <URI>
 
 Check a SVG from a given URI or File for validity
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--fromfile     Fetch from file instead of from URI
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --fromfile     Fetch from file instead of from URI
 

--- a/t/data/app-checksvg-nosvg.error
+++ b/t/data/app-checksvg-nosvg.error
@@ -1,9 +1,9 @@
 Error: No URI specified
 Usage: 05-cmd.t <command> [-?h] [long options...]
-	--help (or -h)  show help
-	                aka -?
+    --help (or -h)  show help
+                    aka -?
 
 05-cmd.t checksvg [long options...] <URI>
-	--profile STR  SVG Profile to validate against
-	               (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
-	--fromfile     Fetch from file instead of from URI
+    --profile STR  SVG Profile to validate against
+                   (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)
+    --fromfile     Fetch from file instead of from URI


### PR DESCRIPTION
test is failed like following:
```
t/05-cmd.t ........................ Name "Mail::BIMI::TestSuite::Resolver" used only once: possible typo at t/05-cmd.t line 26.

        #   Failed test 'STDOUT as expected'
        #   at t/05-cmd.t line 200.
        # +---+--------------------------------------------------------+------------------------------------------------------+
        # | Ln|Got                                                     |Expected                                              |
        # +---+--------------------------------------------------------+------------------------------------------------------+
        # |  1|'05-cmd.t checkdomain [long options...] <DOMAIN>        |'05-cmd.t checkdomain [long options...] <DOMAIN>      |
        # |  2|                                                        |                                                      |
        # |  3|Check the BIMI assertion record for a given domain      |Check the BIMI assertion record for a given domain    |
        # *  4|    --profile STR   SVG Profile to validate against     |\t--profile STR   SVG Profile to validate against     *
        # *  5|                    (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)  |\t                (SVG_1.2_BIMI|SVG_1.2_PS|Tiny-1.2)  *
        # *  6|    --selector STR  Optional selector                   |\t--selector STR  Optional selector                   *
        # |  7|                                                        |                                                      |
        # |  8|'                                                       |'                                                     |
        # +---+--------------------------------------------------------+------------------------------------------------------+
        # Looks like you failed 1 test of 3.

    #   Failed test 'Help'
    #   at t/05-cmd.t line 50.
```

Because [Getopt::Long::Descriptive::Usage](https://metacpan.org/pod/Getopt::Long::Descriptive::Usage) @v0.113 changes TAB to 4 SPACEs.

> 0.113     2023-12-15 16:55:46-05:00 America/New_York
>       - improve line wrapping so spacers (non-option text lines) can use more
>         horizontal characters
>      - replace tabs (generally 8 space) indents in output with four spaces

And I confirmed above modified change:
https://github.com/rjbs/Getopt-Long-Descriptive/commit/b84cb51a8690425294faffca4ef17fb437260326